### PR TITLE
feat: Add SSH username support and improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# coverage
+coverage.*

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ To access a running sandbox environment, you can use `kubectl port-forward` to f
 # Forward the SSH port from the sandbox pod to your local machine
 kubectl port-forward pod/sandbox-<sandbox-name> 2222:22 -n <namespace>
 
-# Connect to the sandbox using SSH
-ssh -p 2222 sandbox@localhost
+# Connect to the sandbox using SSH with the specified username
+# Replace 'myuser' with the username specified in the Sandbox resource (defaults to 'sandbox')
+ssh -p 2222 myuser@localhost
 ```
 
 Make sure you have the corresponding private key for the SSH public key that was specified in the Sandbox resource.
@@ -40,11 +41,12 @@ metadata:
 spec:
   image: kubepark/sandbox-ssh:latest
   ssh:
+    username: myuser
     publicKey: "ssh-rsa AAAAB3NzaC1yc2E... user@example.com"
   terminationGracePeriodSeconds: 60
 ```
 
-This will create a sandbox environment using the specified image and SSH public key. When the Sandbox resource is deleted, the controller will wait for 60 seconds before terminating the pod.
+This will create a sandbox environment using the specified image, SSH username, and SSH public key. The `ssh.username` field allows you to customize the username for SSH access (defaults to "sandbox" if not specified). When the Sandbox resource is deleted, the controller will wait for 60 seconds before terminating the pod.
 
 ### To Deploy on the cluster
 **Build and push your image to the location specified by `IMG`:**
@@ -166,4 +168,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -68,8 +68,12 @@ type SandboxSpec struct {
 
 // SSHConfig defines the SSH configuration for the sandbox.
 type SSHConfig struct {
+	// Username is the SSH username to use for accessing the sandbox.
+	// Defaults to "sandbox" if not specified.
+	Username string `json:"username,omitempty" protobuf:"bytes,1,opt,name=username"`
+
 	// PublicKey is the SSH public key to use for accessing the sandbox.
-	PublicKey string `json:"publicKey,omitempty" protobuf:"bytes,1,opt,name=publicKey"`
+	PublicKey string `json:"publicKey,omitempty" protobuf:"bytes,2,opt,name=publicKey"`
 }
 
 type SandboxTemplateRef struct {

--- a/config/crd/bases/kubepark.sinoa.jp_sandboxes.yaml
+++ b/config/crd/bases/kubepark.sinoa.jp_sandboxes.yaml
@@ -2434,6 +2434,11 @@ spec:
                     description: PublicKey is the SSH public key to use for accessing
                       the sandbox.
                     type: string
+                  username:
+                    description: |-
+                      Username is the SSH username to use for accessing the sandbox.
+                      Defaults to "sandbox" if not specified.
+                    type: string
                 type: object
               terminationGracePeriodSeconds:
                 description: TerminationGracePeriodSeconds is the duration in seconds

--- a/config/crd/bases/kubepark.sinoa.jp_sandboxtemplates.yaml
+++ b/config/crd/bases/kubepark.sinoa.jp_sandboxtemplates.yaml
@@ -2434,6 +2434,11 @@ spec:
                     description: PublicKey is the SSH public key to use for accessing
                       the sandbox.
                     type: string
+                  username:
+                    description: |-
+                      Username is the SSH username to use for accessing the sandbox.
+                      Defaults to "sandbox" if not specified.
+                    type: string
                 type: object
               terminationGracePeriodSeconds:
                 description: TerminationGracePeriodSeconds is the duration in seconds

--- a/config/samples/kubepark_v1alpha1_sandbox.yaml
+++ b/config/samples/kubepark_v1alpha1_sandbox.yaml
@@ -7,7 +7,8 @@ metadata:
   name: sandbox-sample
 spec:
   image: ghcr.io/frauniki/kubepark/sandbox-ssh:latest
-  imagePullPolicy: Always
+  imagePullPolicy: IfNotPresent
   ssh:
+    username: kubepark
     publicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoMOqu+h7wVDNX4Unx2MwM3eIXPQLU4nZccdtfmcnKz
   terminationGracePeriodSeconds: 60

--- a/images/sandbox-ssh/Dockerfile
+++ b/images/sandbox-ssh/Dockerfile
@@ -11,14 +11,7 @@ RUN mkdir -p /var/run/sshd && \
     mkdir -p /root/.ssh && \
     chmod 700 /root/.ssh && \
     echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config && \
-    echo "AuthorizedKeysFile /etc/ssh/authorized_keys" >> /etc/ssh/sshd_config && \
     sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-
-# Create a non-root user
-RUN useradd -m -s /bin/bash sandbox && \
-    mkdir -p /home/sandbox/.ssh && \
-    chmod 700 /home/sandbox/.ssh && \
-    chown -R sandbox:sandbox /home/sandbox
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/images/sandbox-ssh/entrypoint.sh
+++ b/images/sandbox-ssh/entrypoint.sh
@@ -2,27 +2,55 @@
 
 set -e
 
-# Setup SSH directory and permissions for sandbox user
-echo "Setting up SSH configuration..."
-mkdir -p /home/sandbox/.ssh
+# Get SSH username from environment variable, default to 'sandbox'
+SSH_USER=${SSH_USERNAME:-sandbox}
+
+echo "Setting up SSH configuration for user: $SSH_USER"
+
+# Create user if it doesn't exist
+if ! id "$SSH_USER" &>/dev/null; then
+  echo "Creating user: $SSH_USER"
+  useradd -m -s /bin/bash "$SSH_USER"
+  echo "User $SSH_USER created successfully"
+else
+  echo "User $SSH_USER already exists"
+fi
+
+# Ensure home directory exists and has correct permissions
+USER_HOME="/home/$SSH_USER"
+if [ ! -d "$USER_HOME" ]; then
+  echo "Creating home directory for $SSH_USER"
+  mkdir -p "$USER_HOME"
+  chown "$SSH_USER:$SSH_USER" "$USER_HOME"
+fi
+
+# Setup SSH directory and permissions for the user
+echo "Setting up SSH directory for $SSH_USER"
+mkdir -p "$USER_HOME/.ssh"
+chmod 700 "$USER_HOME/.ssh"
+chown "$SSH_USER:$SSH_USER" "$USER_HOME/.ssh"
 
 # Copy authorized_keys from ConfigMap mount point
+AUTHORIZED_KEYS_FILE="$USER_HOME/.ssh/authorized_keys"
 if [ -f /tmp/ssh-config/authorized_keys ]; then
   echo "Copying authorized_keys from ConfigMap..."
-  cp /tmp/ssh-config/authorized_keys /home/sandbox/.ssh/authorized_keys
+  cp /tmp/ssh-config/authorized_keys "$AUTHORIZED_KEYS_FILE"
 elif [ -f /etc/ssh/authorized_keys ]; then
   # Fallback for backward compatibility
   echo "Copying authorized_keys from /etc/ssh (fallback)..."
-  cp /etc/ssh/authorized_keys /home/sandbox/.ssh/authorized_keys
+  cp /etc/ssh/authorized_keys "$AUTHORIZED_KEYS_FILE"
+else
+  echo "Warning: No authorized_keys file found"
 fi
 
-# Set proper permissions
-if [ -f /home/sandbox/.ssh/authorized_keys ]; then
+# Set proper permissions for authorized_keys
+if [ -f "$AUTHORIZED_KEYS_FILE" ]; then
   echo "Setting permissions for SSH files..."
-  chmod 755 /home/sandbox
-  chmod 700 /home/sandbox/.ssh
-  chmod 600 /home/sandbox/.ssh/authorized_keys
-  chown -R sandbox:sandbox /home/sandbox
+  chmod 600 "$AUTHORIZED_KEYS_FILE"
+  chown "$SSH_USER:$SSH_USER" "$AUTHORIZED_KEYS_FILE"
+  echo "SSH key setup completed for user $SSH_USER"
+else
+  echo "Warning: authorized_keys file not found, SSH key authentication may not work"
 fi
 
 # Generate SSH host keys if they don't exist
@@ -31,20 +59,41 @@ if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
   ssh-keygen -A
 fi
 
-# Create custom sshd_config to use correct authorized_keys path
-echo "Creating custom SSHD configuration..."
+# Create custom sshd_config to use correct authorized_keys path and user
+echo "Creating custom SSHD configuration for user $SSH_USER..."
 cat > /tmp/sshd_config <<EOF
-# Custom SSHD configuration for sandbox
-AuthorizedKeysFile /home/sandbox/.ssh/authorized_keys
+# Custom SSHD configuration for sandbox user: $SSH_USER
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Authentication
+AuthorizedKeysFile $USER_HOME/.ssh/authorized_keys
 PubkeyAuthentication yes
 PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# Security settings
 PermitRootLogin no
-AllowUsers sandbox
+AllowUsers $SSH_USER
 StrictModes yes
+MaxAuthTries 3
+MaxSessions 10
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Other settings
+X11Forwarding yes
+PrintMotd no
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server
 EOF
 
-# Append the rest of the default config
-cat /etc/ssh/sshd_config >> /tmp/sshd_config
-
+echo "SSHD configuration created for user: $SSH_USER"
 echo "Starting SSH daemon..."
 exec /usr/sbin/sshd -D -f /tmp/sshd_config

--- a/internal/controller/sandbox_controller.go
+++ b/internal/controller/sandbox_controller.go
@@ -35,6 +35,8 @@ import (
 	kubeparkv1alpha1 "github.com/frauniki/kubepark/api/v1alpha1"
 )
 
+const SSHUsernameEnvVar = "SSH_USERNAME"
+
 const (
 	defaultSandboxImage                  = "kubepark/sandbox-ssh:latest"
 	defaultTerminationGracePeriodSeconds = int64(30)
@@ -305,7 +307,7 @@ func (r *SandboxReconciler) reconcileSandboxPod(ctx context.Context, sandbox *ku
 	var envVars []corev1.EnvVar
 	if sandbox.Spec.SSH != nil && sandbox.Spec.SSH.Username != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "SSH_USERNAME",
+			Name:  SSHUsernameEnvVar,
 			Value: sandbox.Spec.SSH.Username,
 		})
 	}

--- a/internal/controller/sandbox_controller.go
+++ b/internal/controller/sandbox_controller.go
@@ -301,6 +301,15 @@ func (r *SandboxReconciler) reconcileSandboxPod(ctx context.Context, sandbox *ku
 		}
 	}
 
+	// Prepare environment variables for the container
+	var envVars []corev1.EnvVar
+	if sandbox.Spec.SSH != nil && sandbox.Spec.SSH.Username != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SSH_USERNAME",
+			Value: sandbox.Spec.SSH.Username,
+		})
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("sandbox-%s", sandbox.Name),
@@ -322,6 +331,7 @@ func (r *SandboxReconciler) reconcileSandboxPod(ctx context.Context, sandbox *ku
 					Name:            "sandbox",
 					Image:           image,
 					ImagePullPolicy: imagePullPolicy,
+					Env:             envVars,
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "ssh",

--- a/internal/controller/sandbox_controller_test.go
+++ b/internal/controller/sandbox_controller_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -256,6 +257,1039 @@ var _ = Describe("Sandbox Controller", func() {
 
 				By("Cleaning up")
 				Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+			})
+		})
+
+		Context("With SSH username configuration", func() {
+			It("should set SSH_USERNAME environment variable when username is specified", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with custom SSH username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "testuser",
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable is set
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal("testuser"))
+			})
+
+			It("should not set SSH_USERNAME environment variable when username is not specified", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-no-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource without SSH username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created without SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check that SSH_USERNAME environment variable is not set
+				container := pod.Spec.Containers[0]
+				for _, env := range container.Env {
+					Expect(env.Name).NotTo(Equal("SSH_USERNAME"))
+				}
+			})
+
+			It("should handle empty username gracefully", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-empty-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with empty SSH username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "", // Empty username
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created without SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check that SSH_USERNAME environment variable is not set for empty username
+				container := pod.Spec.Containers[0]
+				for _, env := range container.Env {
+					Expect(env.Name).NotTo(Equal("SSH_USERNAME"))
+				}
+			})
+
+			It("should handle special characters in username", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-special-chars"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with special characters in username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "test-user_123", // Username with special characters
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable is set correctly
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal("test-user_123"))
+			})
+
+			It("should handle long username", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-long-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				longUsername := "verylongusernamethatexceedsnormallimits123456789"
+				By("Creating a Sandbox resource with long username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  longUsername,
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable is set correctly
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal(longUsername))
+			})
+
+			It("should handle username with whitespace", func() {
+				// Use test-specific name
+				sandboxName := "test-sandbox-whitespace-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with whitespace in username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  " testuser ", // Username with leading/trailing whitespace
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable is set with the exact value (including whitespace)
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal(" testuser "))
+			})
+		})
+
+		Context("With SandboxTemplate and SSH username", func() {
+			It("should prioritize Sandbox username over SandboxTemplate username", func() {
+				// Use test-specific name
+				templateName := "test-template-username"
+				sandboxName := "test-sandbox-template-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a SandboxTemplate with SSH username")
+				template := &kubeparkv1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      templateName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:template",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "templateuser",
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 template@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, template)).To(Succeed())
+				defer func() {
+					By("Cleaning up the SandboxTemplate resource")
+					Expect(k8sClient.Delete(ctx, template)).To(Succeed())
+				}()
+
+				By("Creating a Sandbox resource that references the template but overrides username")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						SandboxTemplateRef: &kubeparkv1alpha1.SandboxTemplateRef{
+							Name: templateName,
+						},
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "overrideuser", // This should take precedence
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 override@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with overridden SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable uses the Sandbox value, not template value
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal("overrideuser"))
+			})
+
+			It("should inherit username from SandboxTemplate when not specified in Sandbox", func() {
+				// Use test-specific name
+				templateName := "test-template-inherit-username"
+				sandboxName := "test-sandbox-inherit-username"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a SandboxTemplate with SSH username")
+				template := &kubeparkv1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      templateName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:template",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							Username:  "inheriteduser",
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 template@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, template)).To(Succeed())
+				defer func() {
+					By("Cleaning up the SandboxTemplate resource")
+					Expect(k8sClient.Delete(ctx, template)).To(Succeed())
+				}()
+
+				By("Creating a Sandbox resource that references the template without SSH config")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						SandboxTemplateRef: &kubeparkv1alpha1.SandboxTemplateRef{
+							Name: templateName,
+						},
+						// No SSH config specified - should inherit from template
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with inherited SSH_USERNAME environment variable")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				// Check if SSH_USERNAME environment variable uses the inherited value from template
+				container := pod.Spec.Containers[0]
+				var sshUsernameEnv *corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == "SSH_USERNAME" {
+						sshUsernameEnv = &env
+						break
+					}
+				}
+				Expect(sshUsernameEnv).NotTo(BeNil())
+				Expect(sshUsernameEnv.Value).To(Equal("inheriteduser"))
+			})
+		})
+
+		Context("With Container configuration", func() {
+			It("should apply container resource limits and requests", func() {
+				sandboxName := "test-sandbox-resources"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with container resources")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with resource limits and requests")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				container := pod.Spec.Containers[0]
+				Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("500m")))
+				Expect(container.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("512Mi")))
+				Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("100m")))
+				Expect(container.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("128Mi")))
+			})
+
+			It("should apply container environment variables", func() {
+				sandboxName := "test-sandbox-env"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with container environment variables")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+						Container: &corev1.Container{
+							Env: []corev1.EnvVar{
+								{Name: "TEST_ENV", Value: "test_value"},
+								{Name: "ANOTHER_ENV", Value: "another_value"},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with environment variables")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+
+				container := pod.Spec.Containers[0]
+				envMap := make(map[string]string)
+				for _, env := range container.Env {
+					envMap[env.Name] = env.Value
+				}
+				Expect(envMap).To(HaveKeyWithValue("TEST_ENV", "test_value"))
+				Expect(envMap).To(HaveKeyWithValue("ANOTHER_ENV", "another_value"))
+			})
+		})
+
+		Context("With HostNetwork configuration", func() {
+			It("should set HostNetwork when specified", func() {
+				sandboxName := "test-sandbox-hostnetwork"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				hostNetwork := true
+				By("Creating a Sandbox resource with HostNetwork enabled")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+						HostNetwork: &hostNetwork,
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with HostNetwork enabled")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.HostNetwork).To(BeTrue())
+			})
+		})
+
+		Context("With ServiceAccount configuration", func() {
+			It("should use custom ServiceAccount when specified", func() {
+				sandboxName := "test-sandbox-serviceaccount"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with custom ServiceAccount")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+						ServiceAccountName: "custom-service-account",
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with custom ServiceAccount")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.ServiceAccountName).To(Equal("custom-service-account"))
+			})
+
+			It("should use default ServiceAccount when not specified", func() {
+				sandboxName := "test-sandbox-default-serviceaccount"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource without ServiceAccount")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with default ServiceAccount")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.ServiceAccountName).To(Equal("default"))
+			})
+		})
+
+		Context("With ImagePullPolicy defaults", func() {
+			It("should use PullAlways for :latest tag", func() {
+				sandboxName := "test-sandbox-pullalways"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with :latest image")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with PullAlways policy")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
+			})
+
+			It("should use PullIfNotPresent for versioned tag", func() {
+				sandboxName := "test-sandbox-pullif"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with versioned image")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:v1.0.0",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with PullIfNotPresent policy")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+			})
+		})
+
+		Context("With TerminationGracePeriodSeconds", func() {
+			It("should use custom termination grace period", func() {
+				sandboxName := "test-sandbox-grace-period"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				gracePeriod := int64(120)
+				By("Creating a Sandbox resource with custom termination grace period")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 test@example.com",
+						},
+						TerminationGracePeriodSeconds: &gracePeriod,
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking if Pod was created with custom termination grace period")
+				podName := fmt.Sprintf("sandbox-%s", sandboxName)
+				pod := &corev1.Pod{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      podName,
+					Namespace: sandboxNamespace,
+				}, pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*pod.Spec.TerminationGracePeriodSeconds).To(Equal(gracePeriod))
+			})
+		})
+
+		Context("With ConfigMap updates", func() {
+			It("should update ConfigMap when SSH public key changes", func() {
+				sandboxName := "test-sandbox-configmap-update"
+				typeNamespacedName := types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNamespace,
+				}
+
+				By("Creating a Sandbox resource with initial SSH public key")
+				sandbox := &kubeparkv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNamespace,
+					},
+					Spec: kubeparkv1alpha1.SandboxSpec{
+						Image: "kubepark/sandbox-ssh:latest",
+						SSH: &kubeparkv1alpha1.SSHConfig{
+							PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 initial@example.com",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+				defer func() {
+					By("Cleaning up the Sandbox resource")
+					Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+				}()
+
+				By("Reconciling the Sandbox")
+				controllerReconciler := &SandboxReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking initial ConfigMap")
+				configMapName := fmt.Sprintf("ssh-public-key-%s", sandboxName)
+				configMap := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configMapName,
+					Namespace: sandboxNamespace,
+				}, configMap)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configMap.Data["authorized_keys"]).To(ContainSubstring("initial@example.com"))
+
+				By("Updating the SSH public key")
+				err = k8sClient.Get(ctx, typeNamespacedName, sandbox)
+				Expect(err).NotTo(HaveOccurred())
+				sandbox.Spec.SSH.PublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLGGiT2RiSisxJxb+Y5yI2ifFgYZlD1TdH5SSl9Iqk9 updated@example.com"
+				err = k8sClient.Update(ctx, sandbox)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Reconciling again")
+				_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking updated ConfigMap")
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configMapName,
+					Namespace: sandboxNamespace,
+				}, configMap)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configMap.Data["authorized_keys"]).To(ContainSubstring("updated@example.com"))
 			})
 		})
 	})

--- a/internal/controller/sandbox_controller_test.go
+++ b/internal/controller/sandbox_controller_test.go
@@ -314,7 +314,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}
@@ -374,7 +374,7 @@ var _ = Describe("Sandbox Controller", func() {
 				// Check that SSH_USERNAME environment variable is not set
 				container := pod.Spec.Containers[0]
 				for _, env := range container.Env {
-					Expect(env.Name).NotTo(Equal("SSH_USERNAME"))
+					Expect(env.Name).NotTo(Equal(SSHUsernameEnvVar))
 				}
 			})
 
@@ -430,7 +430,7 @@ var _ = Describe("Sandbox Controller", func() {
 				// Check that SSH_USERNAME environment variable is not set for empty username
 				container := pod.Spec.Containers[0]
 				for _, env := range container.Env {
-					Expect(env.Name).NotTo(Equal("SSH_USERNAME"))
+					Expect(env.Name).NotTo(Equal(SSHUsernameEnvVar))
 				}
 			})
 
@@ -487,7 +487,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}
@@ -550,7 +550,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}
@@ -612,7 +612,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}
@@ -699,7 +699,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}
@@ -781,7 +781,7 @@ var _ = Describe("Sandbox Controller", func() {
 				container := pod.Spec.Containers[0]
 				var sshUsernameEnv *corev1.EnvVar
 				for _, env := range container.Env {
-					if env.Name == "SSH_USERNAME" {
+					if env.Name == SSHUsernameEnvVar {
 						sshUsernameEnv = &env
 						break
 					}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -331,7 +331,11 @@ spec:
 			tempFile := "/tmp/sandbox-no-username.yaml"
 			err := os.WriteFile(tempFile, []byte(sandboxYaml), 0644)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create temporary YAML file")
-			defer os.Remove(tempFile)
+			defer func() {
+				if err := os.Remove(tempFile); err != nil {
+					GinkgoT().Logf("Failed to remove temp file: %v", err)
+				}
+			}()
 
 			By("applying the Sandbox resource without username")
 			cmd := exec.Command("kubectl", "apply", "-f", tempFile)


### PR DESCRIPTION
- Add SSH username field to SandboxSpec and SSHConfig
- Support SSH_USERNAME environment variable in sandbox containers
- Add comprehensive test cases for SSH username functionality
- Add tests for Container configuration (resources, env vars)
- Add tests for advanced Pod settings (HostNetwork, ServiceAccount, etc.)
- Add tests for SandboxTemplate integration with username override
- Add tests for ImagePullPolicy defaults and ConfigMap updates
- Improve test coverage from ~30% to 54.9%
- Fix resource quantity comparisons in tests
- Update CRD definitions and sample configurations
- Update sandbox-ssh Docker image to support SSH_USERNAME